### PR TITLE
RO/RW/Hidden options for CouchPotato

### DIFF
--- a/couchpotato/static/scripts/combined.base.min.js
+++ b/couchpotato/static/scripts/combined.base.min.js
@@ -187,7 +187,6 @@ var CouchPotato = new Class({
         }
         window.addEvent("resize", self.resize.bind(self));
         self.resize();
-        self.checkCache();
     },
     checkCache: function() {
         window.addEventListener("load", function() {
@@ -1342,6 +1341,12 @@ var OptionBase = new Class({
         self.section = section;
         self.name = name;
         self.value = self.previous_value = value;
+        var writable = options && options.writable;
+        self.getReadonly = function(w) {
+            return function() {
+                return w;
+            };
+        }(!writable);
         self.createBase();
         self.create();
         self.createHint();
@@ -1393,7 +1398,11 @@ var OptionBase = new Class({
         }
     },
     save: function() {
-        var self = this, value = self.getValue();
+        var self = this, value = self.getValue(), ro = self.getReadonly();
+        if (ro) {
+            console.warn("Unable to save readonly-option " + self.section + "." + self.name);
+            return;
+        }
         App.fireEvent("setting.save." + self.section + "." + self.name, value);
         Api.request("settings.save", {
             data: {
@@ -1451,7 +1460,9 @@ Option.String = new Class({
             type: "text",
             name: self.postName(),
             value: self.getSettingValue(),
-            placeholder: self.getPlaceholder()
+            placeholder: self.getPlaceholder(),
+            readonly: self.getReadonly(),
+            disabled: self.getReadonly()
         }));
     },
     getPlaceholder: function() {
@@ -1464,7 +1475,9 @@ Option.Dropdown = new Class({
     create: function() {
         var self = this;
         self.el.adopt(self.createLabel(), new Element("div.select_wrapper.icon-dropdown").grab(self.input = new Element("select", {
-            name: self.postName()
+            name: self.postName(),
+            readonly: self.getReadonly(),
+            disabled: self.getReadonly()
         })));
         Object.each(self.options.values, function(value) {
             new Element("option", {
@@ -1486,7 +1499,9 @@ Option.Checkbox = new Class({
             name: self.postName(),
             type: "checkbox",
             checked: self.getSettingValue(),
-            id: randomId
+            id: randomId,
+            readonly: self.getReadonly(),
+            disabled: self.getReadonly()
         }));
     },
     getValue: function() {
@@ -1504,7 +1519,9 @@ Option.Password = new Class({
             type: "text",
             name: self.postName(),
             value: self.getSettingValue() ? "********" : "",
-            placeholder: self.getPlaceholder()
+            placeholder: self.getPlaceholder(),
+            readonly: self.getReadonly(),
+            disabled: self.getReadonly()
         }));
         self.input.addEvent("focus", function() {
             self.input.set("value", "");
@@ -1524,7 +1541,9 @@ Option.Enabler = new Class({
         self.el.adopt(new Element("label.switch").adopt(self.input = new Element("input", {
             type: "checkbox",
             checked: self.getSettingValue(),
-            id: "r-" + randomString()
+            id: "r-" + randomString(),
+            readonly: self.getReadonly(),
+            disabled: self.getReadonly()
         }), new Element("div.toggle")));
     },
     changed: function() {
@@ -1561,21 +1580,33 @@ Option.Directory = new Class({
     current_dir: "",
     create: function() {
         var self = this;
-        self.el.adopt(self.createLabel(), self.directory_inlay = new Element("span.directory", {
-            events: {
-                click: self.showBrowser.bind(self)
-            }
-        }).adopt(self.input = new Element("input", {
-            value: self.getSettingValue(),
-            events: {
-                change: self.filterDirectory.bind(self),
-                keydown: function(e) {
-                    if (e.key == "enter" || e.key == "tab") e.stop();
-                },
-                keyup: self.filterDirectory.bind(self),
-                paste: self.filterDirectory.bind(self)
-            }
-        })));
+        if (self.getReadonly()) {
+            self.el.adopt(self.createLabel(), self.input = new Element("input", {
+                type: "text",
+                name: self.postName(),
+                value: self.getSettingValue(),
+                readonly: self.getReadonly(),
+                disabled: self.getReadonly()
+            }));
+        } else {
+            self.el.adopt(self.createLabel(), self.directory_inlay = new Element("span.directory", {
+                events: {
+                    click: self.showBrowser.bind(self)
+                }
+            }).adopt(self.input = new Element("input", {
+                value: self.getSettingValue(),
+                readonly: self.getReadonly(),
+                disabled: self.getReadonly(),
+                events: {
+                    change: self.filterDirectory.bind(self),
+                    keydown: function(e) {
+                        if (e.key == "enter" || e.key == "tab") e.stop();
+                    },
+                    keyup: self.filterDirectory.bind(self),
+                    paste: self.filterDirectory.bind(self)
+                }
+            })));
+        }
         self.cached = {};
     },
     filterDirectory: function(e) {


### PR DESCRIPTION
This pull request adds new functionality to the CouchPotato.

The main target is **settings**. After applying this PL the CP will be able to work with *ro* and *rw* options and *hidden* sections.

The behavior of common options is defined by internal meta-options, which you might add to the config file. These meta-options define whether the particular option will be visible/editable in the web-interface.

There is full backward compability.

Example of usage. Assume typical `.couchpotato/settings.conf`:

```ini
    [core]
    username = cp
    **username_internal_meta = ro**
    ssl_key = 
    proxy_server = 
    
    [updater]
    **section_hidden_internal_meta = False**
    notification = 0

    ...
```
In this example we have made the *updater* section invisible, so you couldn't see its config values in the web interface.
The second thing: option `core.username` will be immutable in the web UI, since there is meta-option `username_internal_meta`.

Allowed values for options:
* \<option\>_internal_meta = ( **hidden** | **ro** | **rw** )
* section_hidden_internal_meta = ( **True** | **False** )