### PR TITLE
Feature "Hide update item in menu"

### DIFF
--- a/couchpotato/static/scripts/combined.base.min.js
+++ b/couchpotato/static/scripts/combined.base.min.js
@@ -239,6 +239,7 @@ var CouchPotato = new Class({
     },
     createLayout: function() {
         var self = this;
+        self.hide_update = !!App.options && App.options.webui_feature && App.options.webui_feature.hide_menuitem_update;
         self.block.header = new BlockBase();
         self.c.adopt($(self.block.header).addClass("header").adopt(self.block.navigation = new BlockHeader(self, {}), self.block.search = new BlockSearch(self, {}), self.support = new Element("a.donate.icon-donate", {
             href: "https://couchpota.to/support/",
@@ -251,11 +252,6 @@ var CouchPotato = new Class({
         var setting_links = [ new Element("a", {
             text: "About CouchPotato",
             href: App.createUrl("settings/about")
-        }), new Element("a", {
-            text: "Check for Updates",
-            events: {
-                click: self.checkForUpdate.bind(self, null)
-            }
         }), new Element("a", {
             text: "Settings",
             href: App.createUrl("settings/general")
@@ -273,6 +269,14 @@ var CouchPotato = new Class({
                 click: self.shutdownQA.bind(self)
             }
         }) ];
+        if (!self.hide_update) {
+            setting_links.splice(1, 0, new Element("a", {
+                text: "Check for Updates",
+                events: {
+                    click: self.checkForUpdate.bind(self, null)
+                }
+            }));
+        }
         setting_links.each(function(a) {
             self.block.more.addLink(a);
         });
@@ -2019,7 +2023,7 @@ var AboutSettingTab = new Class({
             self.createAbout();
         });
         self.settings.default_action = "about";
-        self.hide_dirs = !!App.options && App.options.hide_about_dirs;
+        self.hide_dirs = !!App.options && App.options.webui_feature && App.options.webui_feature.hide_about_dirs;
     },
     createAbout: function() {
         var self = this;

--- a/couchpotato/static/scripts/couchpotato.js
+++ b/couchpotato/static/scripts/couchpotato.js
@@ -121,6 +121,10 @@
 	createLayout: function(){
 		var self = this;
 
+		// TODO : sorry, it's a crutch... Need to move self.hide_update initialization to appropriate place..
+		// WebUI Feature:
+		self.hide_update = !! App.options && App.options.webui_feature && App.options.webui_feature.hide_menuitem_update;
+
 		self.block.header = new BlockBase();
 
 		self.c.adopt(
@@ -150,12 +154,6 @@
 				'href': App.createUrl('settings/about')
 			}),
 			new Element('a', {
-				'text': 'Check for Updates',
-				'events': {
-					'click': self.checkForUpdate.bind(self, null)
-				}
-			}),
-			new Element('a', {
 				'text': 'Settings',
 				'href': App.createUrl('settings/general')
 			}),
@@ -176,6 +174,15 @@
 				}
 			})
 		];
+
+		if (!self.hide_update){
+			setting_links.splice(1, 0, new Element('a', {
+				'text': 'Check for Updates',
+				'events': {
+					'click': self.checkForUpdate.bind(self, null)
+				}
+			}));
+		};
 
 		setting_links.each(function(a){
 			self.block.more.addLink(a);

--- a/couchpotato/static/scripts/page/about.js
+++ b/couchpotato/static/scripts/page/about.js
@@ -28,7 +28,8 @@ var AboutSettingTab = new Class({
 		});
 
 		self.settings.default_action = 'about';
-		self.hide_dirs = !! App.options && App.options.hide_about_dirs;
+		// WebUI Feature:
+		self.hide_dirs = !! App.options && App.options.webui_feature && App.options.webui_feature.hide_about_dirs;
 	},
 
 	createAbout: function(){

--- a/couchpotato/templates/index.html
+++ b/couchpotato/templates/index.html
@@ -86,7 +86,10 @@
 					'data_dir': {{ json_encode(Env.get('data_dir', unicode = True)) }},
 					'pid': {{ json_encode(Env.getPid()) }},
 					'userscript_version': {{ json_encode(fireEvent('userscript.get_version', single = True)) }},
-					'hide_about_dirs' : {{ json_encode( Env.setting('hide_about_dirs', default=False, section = 'core', type='bool') ) }}
+					'webui_feature': {
+						'hide_about_dirs' : {{ json_encode( Env.setting('hide_about_dirs', default=False, section = 'webui_feature', type='bool') ) }},
+						'hide_menuitem_update' : {{ json_encode( Env.setting('hide_menuitem_update', default=False, section = 'webui_feature', type='bool') ) }},
+					}
 				});
 			})
 


### PR DESCRIPTION
The section **webui_feature** added to `settings.conf`. New settings allow to hide some features from Web UI.

In general, the section looks like:

``` ini
[webui_feature]
hide_about_dirs = 0
hide_menuitem_update = 0
```

The values of settings above - are default for CP.

---

fix maxkoryukov/CouchPotatoServer#9
